### PR TITLE
Added imports for fonts Tinos and Fira Sans Condensed.

### DIFF
--- a/static/src/less/article.less
+++ b/static/src/less/article.less
@@ -12,7 +12,7 @@
         border-left: 10px solid lighten(@purple, 15%);
         background-color: lighten(@purple, 45%);
         padding: 30px;
-        font-family: 'OS TT';
+        font-family: 'Fira Sans Condensed', sans-serif;
         color: @dark-grey;
         margin: 0 0 0 60px;
         min-width: 220px;
@@ -44,6 +44,7 @@
         a {
             margin: 5px 0;
             color: @dark-grey;
+            font-family: Tinos, serif;
             text-decoration: none;
             text-transform: lowercase;
             color: @purple;
@@ -64,6 +65,7 @@
 
     .keywords__keyword {
         color: @purple;
+        font-family: Tinos, serif;
         text-decoration: none;
         display: block;
         margin: 3px 0;
@@ -78,11 +80,11 @@
 @media screen and (max-width: 1024px) {
 
     .page__article {
-    
+
         .article__main {
             flex-direction: column;
         }
-    
+
         .article__aside {
             margin: 0;
             width: 100%;
@@ -102,7 +104,7 @@
 @media screen and (max-width: 960px) {
 
     .page__article {
-    
+
         .article__aside {
             flex-direction: column;
         }

--- a/static/src/less/common.less
+++ b/static/src/less/common.less
@@ -49,7 +49,7 @@
 }
 
 p {
-	font-family: "OS TT";
+	font-family: "OS TT", serif;
 	hyphens: manual;
 	text-align: justify;
 	text-indent: 40px;
@@ -61,5 +61,5 @@ p:first-of-type {
 
 h1, h2, h3, h4, h5, label {
 	margin: 0;
-	font-family: 'OS TT';
+	font-family: 'OS TT', serif;
 }

--- a/static/src/less/front-page.less
+++ b/static/src/less/front-page.less
@@ -21,7 +21,7 @@
 
 .article__title {
 	color: @dark-grey;
-	font-family: "sans-serif";
+	font-family: "Fira Sans Condensed", sans-serif;
 	font-size: 22px;
 	margin: 20px 0;
 
@@ -44,7 +44,7 @@
 .one {
 	grid-column: 2 / span 2;
     grid-row: 1 / span 1;
-    
+
     .article__title {
 		a {
 			font-size: 35px;
@@ -78,7 +78,7 @@
 }
 
 .seven {
-	font-family: 'Ariel', sans-serif;
+	font-family: 'Fira Sans Condensed', sans-serif;
 	grid-column: 1 / span 1;
 	grid-row: 4 / span 1;
 	padding: 30px 50px;
@@ -88,7 +88,7 @@
 	line-height: 22px;
 
 	p, a {
-		font-family: 'Ariel', sans-serif;
+		font-family: 'Fira Sans Condensed', sans-serif;
 	}
 
 	a {
@@ -109,7 +109,7 @@
 		padding: 50px 20px;
 		max-width: 860px;
 		margin: 0 auto;
-	
+
 		.article__text {
 			border-top: 3px solid @light-blue;
 			padding: 20px 0;
@@ -125,7 +125,7 @@
 		margin: 10px 0 20px 0;
 	}
 
-	.one {		
+	.one {
 		.article__title {
 			font-size: 25px;
 		}

--- a/static/src/less/header.less
+++ b/static/src/less/header.less
@@ -12,7 +12,7 @@
 .header__date {
     grid-column: 5 /span 1;
     grid-row: 1 / span 1;
-	font-family: "OS TT";
+	font-family: "OS TT", serif;
     color: white;
     font-size: 20px;
     font-weight: normal;
@@ -26,7 +26,7 @@
 	font-size: 18px;
     font-weight: 400;
     text-align: right;
-    
+
     span:nth-child(1) {
         font-weight: 700;
         font-size: 20px;
@@ -65,7 +65,7 @@
 
 .header__link {
     color: white;
-	font-family: "OS TT";
+	font-family: "OS TT", serif;
 	font-weight: normal;
 	font-size: 35px;
 	text-decoration: none;

--- a/static/src/less/navigation.less
+++ b/static/src/less/navigation.less
@@ -10,7 +10,7 @@
 	background-color: lighten(@purple, 12%);
 	display: flex;
 	flex-direction: column;
-	
+
 	font-size: 24px;
 	line-height: 24px;
 
@@ -48,7 +48,7 @@
 	background-color: transparent;
 	height: 50px;
 	width: 50px;
-	
+
 	img {
 		height: 30px;
 		width: 30px;
@@ -69,7 +69,7 @@
 .navigation__item {
 	font-size: 14px;
 	padding: 14px 20px 12px 20px;
-	font-family: "Times New Roman", sans-serif;
+	font-family: "Tinos", serif;
 	font-weight: normal;
 	color: white;
 	text-transform: uppercase;
@@ -86,7 +86,7 @@
 	.navigation {
 		flex-direction: column;
 	}
-    
+
     .navigation__wrapper {
 		flex-direction: column;
 		align-items: center;
@@ -97,12 +97,12 @@
 		flex-direction: column;
 		padding: 10px 0;
 	}
-	
+
 	.navigation__issues {
 		text-align: center;
 		width: 100%;
 		padding: 10px;
-		
+
 		a {
 			width: 100%;
 		}

--- a/static/src/less/page.less
+++ b/static/src/less/page.less
@@ -10,7 +10,7 @@
 
     .article__title {
         color: @dark-grey;
-        font-family: "sans-serif";
+        font-family: "Fira Sans Condensed", sans-serif;
         font-size: 24px;
         margin: 20px 0;
     }
@@ -21,7 +21,7 @@
 
     .article__text {
         border-top: 3px solid @light-blue;
-    
+
         &:nth-child(1) {
             border-top: none;
         }

--- a/static/src/less/text.less
+++ b/static/src/less/text.less
@@ -4,13 +4,13 @@
     margin: 0 auto;
 
     .article__title {
-        margin-top: 0;  
+        margin-top: 0;
     }
 
     h1 {
-        font-family: 'Times New Roman', serif;
+        font-family: 'Fira Sans Condensed', sans-serif;
         font-size: 20px;
-    
+
         &.article__title {
             font-size: 24px;
         }
@@ -18,7 +18,7 @@
 
     h2 {
         font-size: 18px;
-        font-family: 'Times New Roman', serif;
+        font-family: 'Tinos', serif;
         border-left: 10px solid lighten(@purple, 15%);
         color: @dark-grey;
         padding: 0 20px;
@@ -30,7 +30,7 @@
         line-height: 22px;
         font-size: 18px;
         color: @dark-grey;
-        font-family: 'OS TT';
+        font-family: 'OS TT', serif;
     }
 
     .section {
@@ -38,7 +38,7 @@
 
         h1, h2, h3, h4, h5, h6 {
             margin: 0 0 7px 0;
-            font-family: 'Times New Roman', serif;
+            font-family: 'Fira Sans Condensed', sans-serif;
         }
     }
 
@@ -59,7 +59,7 @@
 
         .caption {
             font-size: 16px;
-            font-family: 'Times New Roman', serif;
+            font-family: 'Tinos', serif;
             text-align: right;
         }
     }

--- a/templates/extends/base.html
+++ b/templates/extends/base.html
@@ -7,6 +7,9 @@
 	<title>Български освѣдомитель – {% block title %}{% endblock %}</title>
 
 	<link rel="stylesheet" type="text/css" media="screen" href="{% static 'style.css' %}" />
+	<link href="https://fonts.googleapis.com/css?family=Fira+Sans+Condensed&display=swap" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css?family=Tinos&display=swap" rel="stylesheet">
+
 	<script type="text/javascript" src="{% static 'script.js' %}"></script>
 </head>
 <body class="page-wrapper">
@@ -49,7 +52,7 @@
 		</h1>
 
 		<h2 class="header__subtitle">Новини отъ България. Издание съ мнѣние.</h2>
-		
+
 		<h3 class="header__issue">31 януарий 2020 | година <span>2</span>, брой <span>4</span></h3>
 	</header>
 


### PR DESCRIPTION
Use only three fonts on the site:
* Fira Sans Condensed for most headings
* Tinos for navigation, subtitles and article headings
* Old Standard TT for articles and some other things.

All of these support "ѭ" :)