### PR TITLE
Added typography filter for articles

### DIFF
--- a/orthography/templatetags/typography.py
+++ b/orthography/templatetags/typography.py
@@ -1,0 +1,13 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+from orthography import typography
+
+register = template.Library()
+
+#
+
+@register.filter
+@stringfilter
+def add_typography(value):
+    return typography.add_typography(value)

--- a/orthography/tests/test_typography.py
+++ b/orthography/tests/test_typography.py
@@ -1,0 +1,32 @@
+import unittest
+
+from orthography.typography import convert_dashes, convert_quotes
+
+
+class DashesTestCase(unittest.TestCase):
+
+    def ok(self, ascii_dashes, fancy_dashes):
+        self.assertEqual(convert_dashes(ascii_dashes), fancy_dashes)
+
+    def test_basic(self):
+        self.ok('проба--или не', 'проба–или не')
+        self.ok('наболѣлъ проблемъ подъ тепетата -- градътъ се кичи съ златенъ медалъ',
+                'наболѣлъ проблемъ подъ тепетата – градътъ се кичи съ златенъ медалъ')
+        self.ok('най-новото---и още по-дълго тире', 'най-новото—и още по-дълго тире')
+
+class QuotesTestCase(unittest.TestCase):
+
+    def ok(self, bad_quotes, good_quotes):
+        self.assertEqual(convert_quotes(bad_quotes), good_quotes)
+
+    def test_basic(self):
+        self.ok('язовиръ "Студена", и разрухата', 'язовиръ „Студена“, и разрухата')
+        self.ok('язовиръ “Студена”, и разрухата', 'язовиръ „Студена“, и разрухата')
+        self.ok('язовиръ „Студена”, и разрухата', 'язовиръ „Студена“, и разрухата')
+        self.ok('празни "" въ срѣдата', 'празни „“ въ срѣдата')
+        self.ok('"Началото" и "сѫщото". "Другото", "третото"; "петото".',
+                '„Началото“ и „сѫщото“. „Другото“, „третото“; „петото“.')
+        self.ok('"това"?\n"онова"!', '„това“?\n„онова“!')
+        self.ok('"това":\n"онова";', '„това“:\n„онова“;')
+        self.ok('""', '„“')
+

--- a/orthography/typography.py
+++ b/orthography/typography.py
@@ -1,0 +1,36 @@
+import re
+
+"""
+Filters for some typographic features.
+
+Converts -- to – (n-dash) and --- to — (m-dash).
+
+Converts ASCII double "quotes" to Bulgarian typographic „quotes“.
+Converts wrong typographic „quotes” or “quotes” to „quotes“.
+"""
+
+LEFT_QUOTE_REGEX = re.compile(
+    r"""
+    (?:^|(?<=\s))[\"“„”]
+    """,
+    re.VERBOSE
+)
+
+RIGHT_QUOTE_REGEX = re.compile(
+    r"""
+    [\"“„”](?:$|(?=[\s,:;\.!\?]))
+    """,
+    re.VERBOSE
+)
+
+LEFT_QUOTE = '„'
+RIGHT_QUOTE = '“'
+
+def convert_dashes(text):
+    return text.replace('---', '—').replace('--', '–')
+
+def convert_quotes(text):
+    return RIGHT_QUOTE_REGEX.sub(RIGHT_QUOTE, LEFT_QUOTE_REGEX.sub(LEFT_QUOTE, text))
+
+def add_typography(text):
+    return convert_quotes(convert_dashes(text))

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,6 +1,6 @@
 {% extends "extends/base.html" %}
 
-{% load orthography restructuredtext %}
+{% load orthography restructuredtext typography %}
 
 {% block title %}{{ article.title }}{% endblock %}
 
@@ -21,7 +21,7 @@
 		<article class='article__text'>
 			{% if article.subtitle %}<h2>{{ article.subtitle }}</h2>{% endif %}
 
-			{{ article.text | add_soft_hyphens | rest2html }}
+			{{ article.text | add_typography | add_soft_hyphens | rest2html }}
 		</article>
 
 		<aside class='article__aside'>

--- a/templates/includes/front_page_block.html
+++ b/templates/includes/front_page_block.html
@@ -1,11 +1,11 @@
-{% load orthography restructuredtext %}
+{% load orthography restructuredtext typography %}
 <article class="{{ classes }} article__text" >
 	<h1 class='article__title'>
 		<a href="{{ article.get_absolute_url }}" title="{{ article.title }}">{{ article.title }}</a>
 	</h1>
 	{% if article.subtitle %}<h2>{{ article.subtitle }}</h2>{% endif %}
 	<div class='article__excerpt'>
-		{{ article.text | add_soft_hyphens | rest2html | truncatewords_html:article.truncate_after }}
+		{{ article.text | add_typography | add_soft_hyphens | rest2html | truncatewords_html:article.truncate_after }}
 		<a href="{{ article.get_absolute_url }}" title="{{ article.title }}" class="article__more">Прочети още</a>
 	</div>
 </article>

--- a/templates/includes/list_of_articles.html
+++ b/templates/includes/list_of_articles.html
@@ -1,4 +1,4 @@
-{% load orthography restructuredtext %}
+{% load orthography restructuredtext typography %}
 
 <section class="list__articles">
 	{% for article in articles %}
@@ -7,7 +7,7 @@
 			<a href="{{ article.get_absolute_url }}" title="{{ article.title }}">{{ article.title }}</a>
 		</h1>
 		{% if article.subtitle %}<h2>{{ article.subtitle }}</h2>{% endif %}
-		{{ article.text | add_soft_hyphens | rest2html | truncatewords_html:article.truncate_after }}
+		{{ article.text | add_typography | add_soft_hyphens | rest2html | truncatewords_html:article.truncate_after }}
 		<a href="{{ article.get_absolute_url }}" class='article__more' title="{{ article.title }}">Прочети още</a>
 	</article>
 	{% endfor %}


### PR DESCRIPTION
Converts -- to – (n-dash) and --- to — (m-dash).
Converts ASCII double "quotes" to Bulgarian typographic „quotes“.
Converts wrong typographic „quotes” or “quotes” to „quotes“.